### PR TITLE
Add support for lambdas / lua functions

### DIFF
--- a/autoload/flagship.vim
+++ b/autoload/flagship.vim
@@ -523,6 +523,10 @@ function! flagship#flags_for(type) abort
     unlet! F Hl
     if !empty(get(g:, 'flagship_skip', '')) && str =~# g:flagship_skip
       let flag = ''
+    elseif str =~# '^function('
+      let flag = '%{flagship#call('.str.')}'
+    elseif str =~# '^<lambda>\d\+$'
+      let flag = '%{flagship#call(function('.string(str).'))}'
     elseif str =~# '^\%(\h\|<SNR>\)[[:alnum:]_#]*$' && exists('*'.str)
       let flag = '%{flagship#call('.string(str).')}'
     elseif str =~# '^%!'


### PR DESCRIPTION
This allows doing the following:

```vimscript
autocmd User Flags call Hoist("buffer", {-> "some text"})
" In Neovim
autocmd User Flags call Hoist("buffer", luaeval("function() return 42 end"))
```

or if you're really out there, it makes it possible to use flagship _from_ lua in neovim

```lua
vim.api.nvim_create_autocmd("User", {
  pattern = "Flags",
  callback = function()
    vim.fn.Hoist("buffer", function() return 42 end)
  end,
})
```